### PR TITLE
Adding flask-rev

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Plugins
     - [Flask-gzip](https://github.com/closeio/Flask-gzip) - Gzip flask responses
     - [Flask-HTMLmin](https://github.com/hamidfzm/Flask-HTMLmin) - Flask html minifier
     - [Flask-Azure-Storage](https://github.com/alejoar/Flask-Azure-Storage) - Flask extension that provides integration with Azure Storage 
+    - [Flask-Rev](https://github.com/italomaia/flask-rev) - Easely invalidate old cached static files
 - Development (Debugging/Testing/AB Testing)
     - [flask_profiler](https://github.com/muatik/flask-profiler) - endpoint analyzer/profiler for Flask
     - [Flask-Testing](https://github.com/jarus/flask-testing) - Unittest extensions for Flask


### PR DESCRIPTION
New extension that allows one to make sure aggressive caching rules during deploy do not impact the browser's data freshness